### PR TITLE
MCP enhancements - Language / xmlns 

### DIFF
--- a/iso19139.mcp-1.4/update-fixed-info.xsl
+++ b/iso19139.mcp-1.4/update-fixed-info.xsl
@@ -8,7 +8,7 @@
 						xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 						xmlns:xlink="http://www.w3.org/1999/xlink"
 						xmlns:mcp="http://bluenet3.antcrc.utas.edu.au/mcp"
-						xmlns:gmd="http://www.isotc211.org/2005/gmd">
+						xmlns:gmd="http://www.isotc211.org/2005/gmd"
 
 	<xsl:include href="../iso19139/convert/functions.xsl"/>
 
@@ -410,6 +410,42 @@
 			</xsl:attribute>
 			<xsl:value-of select="."/>
 		</xsl:copy>
+	</xsl:template>
+
+	<!-- ================================================================= -->
+	<!-- Set local identifier to the first 3 letters of iso code. Locale ids
+		are used for multilingual charcterString using #iso2code for referencing.
+	-->
+	<xsl:template match="gmd:PT_Locale">
+		<xsl:element name="gmd:{local-name()}">
+			<xsl:variable name="id" select="upper-case(
+				substring(gmd:languageCode/gmd:LanguageCode/@codeListValue, 1, 3))"/>
+
+			<xsl:apply-templates select="@*"/>
+			<xsl:if test="@id and (normalize-space(@id)='' or normalize-space(@id)!=$id)">
+				<xsl:attribute name="id">
+					<xsl:value-of select="$id"/>
+				</xsl:attribute>
+			</xsl:if>
+			<xsl:apply-templates select="node()"/>
+		</xsl:element>
+	</xsl:template>
+
+	<!-- Apply same changes as above to the gmd:LocalisedCharacterString -->
+	<xsl:variable name="language" select="//gmd:PT_Locale" /> <!-- Need list of all locale -->
+	<xsl:template  match="gmd:LocalisedCharacterString">
+		<xsl:element name="gmd:{local-name()}">
+			<xsl:variable name="currentLocale" select="upper-case(replace(normalize-space(@locale), '^#', ''))"/>
+			<xsl:variable name="ptLocale" select="$language[@id=string($currentLocale)]"/>
+			<xsl:variable name="id" select="upper-case(substring($ptLocale/gmd:languageCode/gmd:LanguageCode/@codeListValue, 1, 3))"/>
+			<xsl:apply-templates select="@*"/>
+			<xsl:if test="$id != '' and ($currentLocale='' or @locale!=concat('#', $id)) ">
+				<xsl:attribute name="locale">
+					<xsl:value-of select="concat('#',$id)"/>
+				</xsl:attribute>
+			</xsl:if>
+			<xsl:apply-templates select="node()"/>
+		</xsl:element>
 	</xsl:template>
 
 	<!-- ================================================================= -->

--- a/iso19139.mcp-1.4/update-fixed-info.xsl
+++ b/iso19139.mcp-1.4/update-fixed-info.xsl
@@ -9,6 +9,7 @@
 						xmlns:xlink="http://www.w3.org/1999/xlink"
 						xmlns:mcp="http://bluenet3.antcrc.utas.edu.au/mcp"
 						xmlns:gmd="http://www.isotc211.org/2005/gmd"
+						exclude-result-prefixes="#all">
 
 	<xsl:include href="../iso19139/convert/functions.xsl"/>
 

--- a/iso19139.mcp/update-fixed-info.xsl
+++ b/iso19139.mcp/update-fixed-info.xsl
@@ -8,7 +8,8 @@
 						xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 						xmlns:xlink="http://www.w3.org/1999/xlink"
 						xmlns:mcp="http://bluenet3.antcrc.utas.edu.au/mcp"
-						xmlns:gmd="http://www.isotc211.org/2005/gmd">
+						xmlns:gmd="http://www.isotc211.org/2005/gmd"
+						exclude-result-prefixes="#all">
 
 	<xsl:include href="../iso19139/convert/functions.xsl"/>
 

--- a/iso19139.mcp/update-fixed-info.xsl
+++ b/iso19139.mcp/update-fixed-info.xsl
@@ -413,6 +413,42 @@
 	</xsl:template>
 
 	<!-- ================================================================= -->
+	<!-- Set local identifier to the first 3 letters of iso code. Locale ids
+		are used for multilingual charcterString using #iso2code for referencing.
+	-->
+	<xsl:template match="gmd:PT_Locale">
+		<xsl:element name="gmd:{local-name()}">
+			<xsl:variable name="id" select="upper-case(
+				substring(gmd:languageCode/gmd:LanguageCode/@codeListValue, 1, 3))"/>
+
+			<xsl:apply-templates select="@*"/>
+			<xsl:if test="@id and (normalize-space(@id)='' or normalize-space(@id)!=$id)">
+				<xsl:attribute name="id">
+					<xsl:value-of select="$id"/>
+				</xsl:attribute>
+			</xsl:if>
+			<xsl:apply-templates select="node()"/>
+		</xsl:element>
+	</xsl:template>
+
+	<!-- Apply same changes as above to the gmd:LocalisedCharacterString -->
+	<xsl:variable name="language" select="//gmd:PT_Locale" /> <!-- Need list of all locale -->
+	<xsl:template  match="gmd:LocalisedCharacterString">
+		<xsl:element name="gmd:{local-name()}">
+			<xsl:variable name="currentLocale" select="upper-case(replace(normalize-space(@locale), '^#', ''))"/>
+			<xsl:variable name="ptLocale" select="$language[@id=string($currentLocale)]"/>
+			<xsl:variable name="id" select="upper-case(substring($ptLocale/gmd:languageCode/gmd:LanguageCode/@codeListValue, 1, 3))"/>
+			<xsl:apply-templates select="@*"/>
+			<xsl:if test="$id != '' and ($currentLocale='' or @locale!=concat('#', $id)) ">
+				<xsl:attribute name="locale">
+					<xsl:value-of select="concat('#',$id)"/>
+				</xsl:attribute>
+			</xsl:if>
+			<xsl:apply-templates select="node()"/>
+		</xsl:element>
+	</xsl:template>
+
+	<!-- ================================================================= -->
 	<!-- Adjust the namespace declaration - In some cases name() is used to get the 
 		element. The assumption is that the name is in the format of  <ns:element> 
 		however in some cases it is in the format of <element xmlns=""> so the 


### PR DESCRIPTION
Ported ticket #957 to MCP - which adds better support for multiple languages.
remove clutter  xmlns  by applying exclude-result-prefixes="#all"
