### PR TITLE
Fix MCP XSL error when multiple hierarchyLevel are set

### DIFF
--- a/iso19139.mcp-1.4/schematron/schematron-rules-iso-mcp.sch
+++ b/iso19139.mcp-1.4/schematron/schematron-rules-iso-mcp.sch
@@ -490,14 +490,16 @@ USA.
 	<sch:pattern>
 		<sch:title>$loc/strings/M61</sch:title>
 		<sch:rule context="//gmd:MD_Metadata/gmd:hierarchyLevel|//*[@gco:isoType='gmd:MD_Metadata']/gmd:hierarchyLevel">
-			<sch:let name="hl" value="(gmd:MD_ScopeCode/@codeListValue!='' and gmd:MD_ScopeCode/@codeListValue!='dataset') and 
+			<sch:let name="hl" value="count(../gmd:hierarchyLevel/gmd:MD_ScopeCode[@codeListValue='dataset' or @codeListValue=''])=0 and
 				(not(../gmd:hierarchyLevelName) or ../gmd:hierarchyLevelName/@gco:nilReason)"/>
+			<sch:let name="resourceType" value="string-join(../gmd:hierarchyLevel/*/@codeListValue, ',')"/>
+
 			<sch:assert
 				test="$hl = false()"
 				>$loc/strings/alert.M61</sch:assert>
 			<sch:report
 				test="$hl = false()"
-				><sch:value-of select=" $loc/strings/report.M61"/> "<sch:value-of select="../gmd:hierarchyLevelName"/>"</sch:report>
+				><sch:value-of select=" $loc/strings/report.M61"/> "<sch:value-of select="$resourceType"/>"</sch:report>
 		</sch:rule>
 	</sch:pattern>
 

--- a/iso19139.mcp-2.0/schematron/schematron-rules-iso-mcp-2.0.sch
+++ b/iso19139.mcp-2.0/schematron/schematron-rules-iso-mcp-2.0.sch
@@ -490,14 +490,16 @@ USA.
 	<sch:pattern>
 		<sch:title>$loc/strings/M61</sch:title>
 		<sch:rule context="//gmd:MD_Metadata/gmd:hierarchyLevel|//*[@gco:isoType='gmd:MD_Metadata']/gmd:hierarchyLevel">
-			<sch:let name="hl" value="(gmd:MD_ScopeCode/@codeListValue!='' and gmd:MD_ScopeCode/@codeListValue!='dataset') and 
+			<sch:let name="hl" value="count(../gmd:hierarchyLevel/gmd:MD_ScopeCode[@codeListValue='dataset' or @codeListValue=''])=0 and
 				(not(../gmd:hierarchyLevelName) or ../gmd:hierarchyLevelName/@gco:nilReason)"/>
+			<sch:let name="resourceType" value="string-join(../gmd:hierarchyLevel/*/@codeListValue, ',')"/>
+
 			<sch:assert
 				test="$hl = false()"
 				>$loc/strings/alert.M61</sch:assert>
 			<sch:report
 				test="$hl = false()"
-				><sch:value-of select=" $loc/strings/report.M61"/> "<sch:value-of select="../gmd:hierarchyLevelName"/>"</sch:report>
+				><sch:value-of select=" $loc/strings/report.M61"/> "<sch:value-of select="$resourceType"/>"</sch:report>
 		</sch:rule>
 	</sch:pattern>
 

--- a/iso19139.mcp/schematron/schematron-rules-iso-mcp.sch
+++ b/iso19139.mcp/schematron/schematron-rules-iso-mcp.sch
@@ -490,14 +490,16 @@ USA.
 	<sch:pattern>
 		<sch:title>$loc/strings/M61</sch:title>
 		<sch:rule context="//gmd:MD_Metadata/gmd:hierarchyLevel|//*[@gco:isoType='gmd:MD_Metadata']/gmd:hierarchyLevel">
-			<sch:let name="hl" value="(gmd:MD_ScopeCode/@codeListValue!='' and gmd:MD_ScopeCode/@codeListValue!='dataset') and 
+			<sch:let name="hl" value="count(../gmd:hierarchyLevel/gmd:MD_ScopeCode[@codeListValue='dataset' or @codeListValue=''])=0 and
 				(not(../gmd:hierarchyLevelName) or ../gmd:hierarchyLevelName/@gco:nilReason)"/>
+			<sch:let name="resourceType" value="string-join(../gmd:hierarchyLevel/*/@codeListValue, ',')"/>
+
 			<sch:assert
 				test="$hl = false()"
 				>$loc/strings/alert.M61</sch:assert>
 			<sch:report
 				test="$hl = false()"
-				><sch:value-of select=" $loc/strings/report.M61"/> "<sch:value-of select="../gmd:hierarchyLevelName"/>"</sch:report>
+				><sch:value-of select=" $loc/strings/report.M61"/> "<sch:value-of select="$resourceType"/>"</sch:report>
 		</sch:rule>
 	</sch:pattern>
 


### PR DESCRIPTION
Applied commit from ticket http://trac.osgeo.org/geonetwork/ticket/406 to MCP
https://github.com/geonetwork/core-geonetwork/commit/b93fdfd4b0e3f2a754e026b6fa5ad86a3349dd0e#diff-c1cd68efff5e65dbafc49a95adb0b721L449
