### PR TITLE
Added missing label for check M32 and M33

### DIFF
--- a/iso19139.mcp-1.4/loc/eng/schematron-rules-iso-mcp.xml
+++ b/iso19139.mcp-1.4/loc/eng/schematron-rules-iso-mcp.xml
@@ -25,6 +25,8 @@
     <M28>[ISOFTDS19139:2005-TableA1-Row21] - DomainCode</M28>
     <M29>[ISOFTDS19139:2005-TableA1-Row22] - ShortName</M29>
     <M30>[ISOFTDS19139:2005-TableA1-Row15] - Check point description required if available</M30>
+    <M32>A name is required for and organisation</M32>
+    <M33>A name or position is required for and individual</M33>
     <M61>[ISOFTDS19139:2005-TableA1] - HierarchyLevelName must be documented if hierarchyLevel does not contain "dataset"</M61>
     
     

--- a/iso19139.mcp/loc/eng/schematron-rules-iso-mcp.xml
+++ b/iso19139.mcp/loc/eng/schematron-rules-iso-mcp.xml
@@ -25,6 +25,8 @@
     <M28>[ISOFTDS19139:2005-TableA1-Row21] - DomainCode</M28>
     <M29>[ISOFTDS19139:2005-TableA1-Row22] - ShortName</M29>
     <M30>[ISOFTDS19139:2005-TableA1-Row15] - Check point description required if available</M30>
+    <M32>A name is required for and organisation</M32>
+    <M33>A name or position is required for and individual</M33>
     <M61>[ISOFTDS19139:2005-TableA1] - HierarchyLevelName must be documented if hierarchyLevel does not contain "dataset"</M61>
     
     


### PR DESCRIPTION
I'm not sure if there is a reference to these checks in ISOFTDS19139:2005-TableA1 - if so then you may want to specify the row # for this error.
